### PR TITLE
Modular scale for H1 should be set to 2

### DIFF
--- a/patterns/base/h1/sass/partials/_extends.scss
+++ b/patterns/base/h1/sass/partials/_extends.scss
@@ -1,4 +1,4 @@
 %base--h1 {
   @extend %font--sans;
-  font-size: ms(1);
+  font-size: ms(2);
 }


### PR DESCRIPTION
This will make the other typographic sizing accurate
