### PR TITLE
Adding !optional to @extend %base--font-weight;

### DIFF
--- a/patterns/base/body/sass/partials/_extends.scss
+++ b/patterns/base/body/sass/partials/_extends.scss
@@ -1,5 +1,5 @@
 %body--typography {
   @extend %font--sans;
-  @extend %base--font-weight;
+  @extend %base--font-weight !optional;
   line-height: 1.5;
 }


### PR DESCRIPTION
This resolves the error we've been seeing when trying to generate the WDC website today:

> Error: "%body--typography" failed to @extend "%base--font-weight".
> The selector "%base--font-weight" was not found.
> Use "@extend %base--font-weight !optional" if the extend should be able to fail.
