### PR TITLE
Tweak to make %base--font-weight optional

### DIFF
--- a/patterns/base/body/sass/partials/_extends.scss
+++ b/patterns/base/body/sass/partials/_extends.scss
@@ -1,5 +1,5 @@
 %body--typography {
   @extend %font--sans;
-  @extend %base--font-weight;
+  @extend %base--font-weight !optional;
   line-height: 1.5;
 }


### PR DESCRIPTION
I'm not sure why, but the WDC website can't build with out this change. Perhaps its a libsass vs (ruby) sass thing?